### PR TITLE
updates build-tools to install go1.13.3

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -1,17 +1,25 @@
 FROM fedora:30 as build-tools
 ENV GOPATH /go
 ENV GOBIN /go/bin
+ENV GOROOT /usr/local/go
 ENV GOCACHE /go/.cache
 ARG GO_PACKAGE_PATH=github.com/openshift/ocs-operator
 
 # rpms required for building and running test suites
 RUN dnf -y install \
-    golang \
     make \
+    wget \
+    git \
     tar \
     findutils \
     python3 \
     && dnf clean all
+
+# dnf install golang pulls go1.12, so manually pulling go1.13.3
+RUN wget https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz
+RUN tar -xzf go1.13.3.linux-amd64.tar.gz && mv go /usr/local
+ENV PATH=$GOPATH/bin:$GOROOT/bin:$PATH
+ENV GO111MODULE=on
 
 # get required golang tools and OC client
 RUN go get github.com/onsi/ginkgo/ginkgo && \
@@ -21,8 +29,6 @@ RUN go get github.com/onsi/ginkgo/ginkgo && \
     curl -JL https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/${latest_oc_client_version} -o oc.tar.gz && \
     tar -xzvf oc.tar.gz && \
     mv oc /usr/bin/oc
-
-ENV PATH=$PATH:$GOPATH/bin
 
 RUN export TMP_BIN=$(mktemp -d) && \
     mv $GOBIN/* $TMP_BIN/ && \


### PR DESCRIPTION
go1.13.3 with GO111MODULE=on is required for builds & tests
to be successful.

Signed-off-by: Umanga Chapagain <chapagainumanga@gmail.com>